### PR TITLE
Reduce backwards compatibility in favor of more logical edits

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -50,10 +50,8 @@ function suggest(value) {
   var normalized
   var suggestion
   var currentCase
-  var valueLowerCase
 
   value = normalize(value.trim(), conversion.in)
-  valueLowerCase = value.toLowerCase()
 
   if (!value || self.correct(value)) {
     return []
@@ -81,22 +79,20 @@ function suggest(value) {
 
   while (++index < length) {
     group = groups[index]
-    // Only make edits to the start of value, bound by group size
-    count = Math.min(value.length, group.length)
+    count = value.length
     offset = -1
 
     while (++offset < count) {
-      // Consider edits where value contains character at offset in group
-      position = valueLowerCase.indexOf(group.charAt(offset))
-
-      if (position === -1) {
-        continue
-      }
-
       character = value.charAt(offset)
       insensitive = character.toLowerCase()
       upper = insensitive !== character
       charAdded = offsetAdded[offset] || {}
+
+      position = group.indexOf(insensitive)
+
+      if (position === -1) {
+        continue
+      }
 
       before = value.slice(0, offset)
       after = value.slice(offset + 1)


### PR DESCRIPTION
This is a PR against the existing [wooorm/nspell PR #39](https://github.com/wooorm/nspell/pull/39). It's an attempt to further address the [broken keyboard group logic](https://github.com/wooorm/nspell/issues/41) I've discovered with nspell.

Please [**have a look at the files changed**](https://github.com/tvquizphd/nspell/pull/1/files). I've framed these edits in a way that shows how this PR **makes more sense** when thinking about how "keyboard group replacement" should operate.

### The base branch passes all but one test by keeping part of the broken keyboard logic

- [x] Fixes the [capitalization issue](https://github.com/wooorm/nspell/issues/37)
- [x] Fixes the [short-word problem](https://github.com/wooorm/nspell/issues/41#short-words)
- [ ] **Does not fix** the [long-word problem](https://github.com/wooorm/nspell/issues/41#long-words)
- [ ] **Benignly Fails** test [#46](https://github.com/wooorm/nspell/blob/main/test/index.js#L265)
  - the output is [ 'Brandi', 'Shandy', 'handy', 'Ghana', 'Grand', 'Grandee', 'Grands', 'Shanxi', 'hand', 'hands' ]
- [x] **Passes** tests [#45](https://github.com/wooorm/nspell/blob/main/test/index.js#L259) and [#53](https://github.com/wooorm/nspell/blob/main/test/index.js#L304) exactly

### This PR fails three tests, but uses "correct" keyboard logic

- [x] Fixes the [capitalization issue](https://github.com/wooorm/nspell/issues/37)
- [x] Fixes the [short-word problem](https://github.com/wooorm/nspell/issues/41#short-words)
- [x] **Fixes** the [long-word problem](https://github.com/wooorm/nspell/issues/41#long-words)
- [ ] **Benignly Fails** test [#46](https://github.com/wooorm/nspell/blob/main/test/index.js#L265)
  - the output is [ 'Brandi', 'Ghana', 'Grandee', 'Shanxi', 'hand', 'hands', 'handy' ]
- [ ] **Benignly Fails** tests [#45](https://github.com/wooorm/nspell/blob/main/test/index.js#L259) and [#53](https://github.com/wooorm/nspell/blob/main/test/index.js#L304)
   - by weighing **proper** over **dropper** for input **propper**
   - by weighing **colloq** over **color** for input **collor**